### PR TITLE
Make errors always show as red

### DIFF
--- a/callbacks/anstomlog.py
+++ b/callbacks/anstomlog.py
@@ -263,7 +263,7 @@ class CallbackModule(CallbackBase):
         self._emit_line("%s | FAILED | %dms" %
                         (host_string,
                          duration), color='red')
-        self._emit_line(deep_serialize(result._result), color='cyan')
+        self._emit_line(deep_serialize(result._result), color='red')
 
     def v2_on_file_diff(self, result):
 


### PR DESCRIPTION
Currently all failed tasks show as cyan for my playbooks. I found that this line makes them red again.