### PR TITLE
correct duration accuracy

### DIFF
--- a/callbacks/anstomlog.py
+++ b/callbacks/anstomlog.py
@@ -195,8 +195,7 @@ class CallbackModule(CallbackBase):
     def _get_duration(self):
         end = datetime.now()
         total_duration = (end - self.tark_started)
-        duration = total_duration.microseconds / \
-            1000 + total_duration.total_seconds() * 1000
+        duration = total_duration.total_seconds() * 1000
         return duration
 
     def _command_generic_msg(self, hostname, result, caption):


### PR DESCRIPTION
Spotted that the milliseconds on the _get_duration method are always doubled. Consider the following:

```python
from datetime import datetime
from time import sleep

def dur(sl, bug=False):
    start = datetime.now()
    sleep(sl)
    end = datetime.now()
    total_duration = (end - start)
    if bug:
        return total_duration.microseconds / \ 
            1000 + total_duration.total_seconds() * 1000
    else:
        return total_duration.total_seconds() * 1000

test=[0.01,0.12,1.24]

for x in test:
    print("%dms" % dur(x,True))
for x in test:
    print("%dms" % dur(x))

```

which results in:
```
20ms
240ms
1482ms
10ms
120ms
1241ms
```