### PR TITLE
Fix warning  "Invalid color supplied"

### DIFF
--- a/callbacks/anstomlog.py
+++ b/callbacks/anstomlog.py
@@ -343,7 +343,7 @@ class CallbackModule(CallbackBase):
 
         return [msg, color]
 
-    def _emit_line(self, lines, color='normal'):
+    def _emit_line(self, lines, color='green'):
 
         if self.task_start_preamble is None:
             self._open_section("system")


### PR DESCRIPTION
In ansible 2.9.0, the callback plugin generate the warning "Invalid color supplied to display: normal"