### PR TITLE
Format duration

### DIFF
--- a/callbacks/anstomlog.py
+++ b/callbacks/anstomlog.py
@@ -196,7 +196,11 @@ class CallbackModule(CallbackBase):
     def _get_duration(self):
         end = datetime.now()
         total_duration = (end - self.tark_started)
-        duration = total_duration.total_seconds() * 1000
+        seconds = total_duration.total_seconds()
+        if seconds >= 1:
+            duration = "{0:.2f}s".format(seconds)
+        else:
+            duration = "{0:.0f}ms".format(seconds * 1000)
         return duration
 
     def _command_generic_msg(self, hostname, result, caption):
@@ -206,18 +210,18 @@ class CallbackModule(CallbackBase):
         if self._display.verbosity > 0:
             if 'stderr' in result and result['stderr']:
                 stderr = result.get('stderr', '')
-                return "%s | %s | %sms | rc=%s | stdout: \n%s\n\n\t\t\t\tstderr: %s" % \
+                return "%s | %s | %s | rc=%s | stdout: \n%s\n\n\t\t\t\tstderr: %s" % \
                     (hostname, caption, duration,
                      result.get('rc', 0), stdout, stderr)
             else:
                 if len(stdout) > 0:
-                    return "%s | %s | %sms | rc=%s | stdout: \n%s\n" % \
+                    return "%s | %s | %s | rc=%s | stdout: \n%s\n" % \
                         (hostname, caption, duration, result.get('rc', 0), stdout)
                 else:
-                    return "%s | %s | %sms | rc=%s | no stdout" % \
+                    return "%s | %s | %s | rc=%s | no stdout" % \
                         (hostname, caption, duration, result.get('rc', 0))
         else:
-            return "%s | %s | %sms | rc=%s" % (hostname, caption, duration, result.get('rc', 0))
+            return "%s | %s | %s | rc=%s" % (hostname, caption, duration, result.get('rc', 0))
 
     def v2_playbook_on_task_start(self, task, is_conditional):
         # pylint: disable=I0011,W0613
@@ -265,7 +269,7 @@ class CallbackModule(CallbackBase):
 
                 self._emit_line(msg, color='red')
 
-        self._emit_line("%s | FAILED | %dms" %
+        self._emit_line("%s | FAILED | %s" %
                         (host_string,
                          duration), color='red')
         self._emit_line(deep_serialize(result._result), color='red')
@@ -318,10 +322,10 @@ class CallbackModule(CallbackBase):
             for item in result._result['results']:
                 msg, color = self._changed_or_not(item, host_string)
                 item_msg = "%s - item=%s" % (msg, self._get_item(item))
-                self._emit_line("%s | %dms" %
+                self._emit_line("%s | %s" %
                                 (item_msg, duration), color=color)
         else:
-            self._emit_line("%s | %dms" %
+            self._emit_line("%s | %s" %
                             (msg, duration), color=color)
         self._handle_warnings(result._result)
 
@@ -364,7 +368,7 @@ class CallbackModule(CallbackBase):
         duration = self._get_duration()
         self._task_level = 0
 
-        self._emit_line("%s | SKIPPED | %dms" %
+        self._emit_line("%s | SKIPPED | %s" %
                         (self._host_string(result), duration), color='cyan')
 
     def v2_playbook_on_include(self, included_file):

--- a/callbacks/anstomlog.py
+++ b/callbacks/anstomlog.py
@@ -197,7 +197,11 @@ class CallbackModule(CallbackBase):
         end = datetime.now()
         total_duration = (end - self.tark_started)
         seconds = total_duration.total_seconds()
-        if seconds >= 1:
+        if seconds >= 60:
+            seconds_remaining = seconds % 60
+            minutes = (seconds - seconds_remaining) / 60
+            duration = "{0:.0f}m{1:.0f}s".format(minutes, seconds_remaining)
+        elif seconds >= 1:
             duration = "{0:.2f}s".format(seconds)
         else:
             duration = "{0:.0f}ms".format(seconds * 1000)
@@ -228,7 +232,7 @@ class CallbackModule(CallbackBase):
         self._open_section(task.get_name(), task.get_path())
         self._task_level += 1
 
-    def _open_section(self, section_name, path = None):
+    def _open_section(self, section_name, path=None):
         # pylint: disable=I0011,W0201
         self.tark_started = datetime.now()
 
@@ -237,14 +241,13 @@ class CallbackModule(CallbackBase):
             prefix = '  ➥'
 
         ts = self.tark_started.strftime(
-                "%H:%M:%S")
+            "%H:%M:%S")
         if self._display.verbosity > 1:
             if path:
                 self._emit_line("[{}]: {}".format(ts, path))
         self.task_start_preamble = "[{}]{} {} ...".format(
-            ts , prefix, section_name)
+            ts, prefix, section_name)
         sys.stdout.write(self.task_start_preamble)
-
 
     def v2_playbook_on_handler_task_start(self, task):
         self._emit_line("triggering handler | %s " % task.get_name().strip())

--- a/test-long.yml
+++ b/test-long.yml
@@ -1,0 +1,19 @@
+---
+- name: "Test single execution"
+  hosts: localhost
+  vars:
+    version: coucou
+  tasks:
+    - name: Long running task (1m2s)
+      command: "sleep 62"
+    - name: "Secret action"
+      command: "sleep 1"
+      no_log: True
+    - name: "Validate version is a number, > 0"
+      assert:
+        that:
+          - "{{ version | int }} != 0"
+        msg: "'version' must be a number and > 0, is \"{{version}}\""
+
+  roles:
+    - test-role


### PR DESCRIPTION
I don't know if this is a feature that you or your users would like, but my team agreed that it would be useful.

Instead of always returning the duration in ms, only return ms if the duration is less than 1 second such as 376ms. If the duration is less than 1 minute and more than 1 second, return seconds to 2 decimal places such as 34.27s.  If the duration is more than a minute, return the minutes and seconds such as 5m35s.

Any suggestions are welcome.  I'm not a python expert by any means, so there could definitely be a cleaner way of doing this.  Thanks for the consideration.